### PR TITLE
workflow: add a well-deserved CI/CD action. Is the build number even?

### DIFF
--- a/.github/workflows/is-build-even.yml
+++ b/.github/workflows/is-build-even.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  is-even:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Is build number even?
+        run: '[[ $((${{github.run_number}} & 1)) -eq 0 ]]'


### PR DESCRIPTION
Don't you hate it, when your build passes even on odd numbers?

We don't want to confuse users. If it's not even, it's gotta go DOWN.